### PR TITLE
Adding SNIP20 interface

### DIFF
--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "secret-toolkit-snip20"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+serde = "1.0"
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+secret-toolkit-utils = { path = "../utils" }

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 serde = "1.0"
 cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
 secret-toolkit-utils = { path = "../utils" }
+schemars = "0.7"

--- a/packages/snip20/Readme.md
+++ b/packages/snip20/Readme.md
@@ -6,9 +6,7 @@ These functions are meant to help you easily interact with SNIP20 compliant toke
 
 You can create a HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `messages` Vec.
 
-
 Or you can call the individual function for each Handle message to generate the appropriate callback CosmosMsg.
-
 
 You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to also mask the length of the viewing key your contract has generated.
 
@@ -58,6 +56,5 @@ pub struct Minters {
 }
 ```
 You can create a QueryMsg variant and call the `query` function to query a SNIP20 token contract.
-
 
 Or you can call the individual function for each query.

--- a/packages/snip20/Readme.md
+++ b/packages/snip20/Readme.md
@@ -4,15 +4,18 @@ These functions are meant to help you easily interact with SNIP20 compliant toke
 
 ## Handle Messages
 
-You can create a Snip20HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `messages` Vec.<br/>
-Or you can call the individual function for each Handle message.<br/>
+You can create a HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `messages` Vec.
+
+
+Or you can call the individual function for each Handle message to generate the appropriate callback CosmosMsg.
+
+
 You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to also mask the length of the viewing key your contract has generated.
 
 ## Queries
 
 These are the types that SNIP20 tokens can return from queries
 ```rust
-#[derive(Serialize, Deserialize)]
 pub struct TokenInfo {
     pub name: String,
     pub symbol: String,
@@ -20,12 +23,12 @@ pub struct TokenInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_supply: Option<Uint128>,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct ExchangeRate {
     pub rate: Uint128,
     pub denom: String,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct Allowance {
     pub spender: HumanAddr,
     pub owner: HumanAddr,
@@ -33,11 +36,11 @@ pub struct Allowance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<u64>,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct Balance {
     pub amount: Uint128,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct Tx {
     pub id: u64,
     pub from: HumanAddr,
@@ -45,14 +48,16 @@ pub struct Tx {
     pub receiver: HumanAddr,
     pub coins: Coin,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct TransferHistory {
     pub txs: Vec<Tx>,
 }
-#[derive(Serialize, Deserialize)]
+
 pub struct Minters {
     pub minters: Vec<HumanAddr>,
 }
 ```
-You can create a Snip20QueryMsg variant and call the `query` function to query a SNIP20 token contract.<br/>
-Or you can call the individual function for each query.<br/>
+You can create a QueryMsg variant and call the `query` function to query a SNIP20 token contract.
+
+
+Or you can call the individual function for each query.

--- a/packages/snip20/Readme.md
+++ b/packages/snip20/Readme.md
@@ -4,7 +4,7 @@ These functions are meant to help you easily interact with SNIP20 compliant toke
 
 ## Handle Messages
 
-You can create a Snip20HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `message` Vec.<br/>
+You can create a Snip20HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `messages` Vec.<br/>
 Or you can call the individual function for each Handle message.<br/>
 You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to also mask the length of the viewing key your contract has generated.
 

--- a/packages/snip20/Readme.md
+++ b/packages/snip20/Readme.md
@@ -1,0 +1,58 @@
+# Secret Contract Development Toolkit - SNIP20 Interface
+
+These functions are meant to help you easily interact with SNIP20 compliant tokens.  
+
+## Handle Messages
+
+You can create a Snip20HandleMsg variant and call the `to_cosmos_msg` function to generate the CosmosMsg that shoud be pushed onto the InitResponse or HandleResponse `message` Vec.<br/>
+Or you can call the individual function for each Handle message.<br/>
+You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to also mask the length of the viewing key your contract has generated.
+
+## Queries
+
+These are the types that SNIP20 tokens can return from queries
+```rust
+#[derive(Serialize, Deserialize)]
+pub struct TokenInfo {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_supply: Option<Uint128>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct ExchangeRate {
+    pub rate: Uint128,
+    pub denom: String,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Allowance {
+    pub spender: HumanAddr,
+    pub owner: HumanAddr,
+    pub allowance: Uint128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration: Option<u64>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Balance {
+    pub amount: Uint128,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Tx {
+    pub id: u64,
+    pub from: HumanAddr,
+    pub sender: HumanAddr,
+    pub receiver: HumanAddr,
+    pub coins: Coin,
+}
+#[derive(Serialize, Deserialize)]
+pub struct TransferHistory {
+    pub txs: Vec<Tx>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Minters {
+    pub minters: Vec<HumanAddr>,
+}
+```
+You can create a Snip20QueryMsg variant and call the `query` function to query a SNIP20 token contract.<br/>
+Or you can call the individual function for each query.<br/>

--- a/packages/snip20/src/handle.rs
+++ b/packages/snip20/src/handle.rs
@@ -11,7 +11,7 @@ pub enum Snip20HandleMsg<'a> {
     /// Native coin interactions
     Redeem {
         amount: Uint128,
-        // TO DO: remove skip_serializing once denom is added to reference impl
+        // TO DO: remove skip_serializing once denom is added to sSCRT stored on mainnet
         #[serde(skip_serializing_if = "Option::is_none")]
         denom: Option<String>,
         padding: Option<String>,
@@ -75,9 +75,8 @@ pub enum Snip20HandleMsg<'a> {
 
     /// Mint
     Mint {
+        recipient: &'a HumanAddr,
         amount: Uint128,
-        // TO DO change name to recipient when reference impl does
-        address: &'a HumanAddr,
         padding: Option<String>,
     },
     AddMinters {
@@ -148,7 +147,7 @@ impl<'a> Snip20HandleMsg<'a> {
 /// # Arguments
 ///
 /// * `amount` - Uint128 amount of token to redeem for SCRT
-/// * `denom` - Optional String to hold denomination of tokens to mint
+/// * `denom` - Optional String to hold denomination of tokens to redeem
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad message to blocks of this size
 /// * `callback_code_hash` - string slice holding the code hash of contract being called
@@ -469,24 +468,23 @@ pub fn burn_from_msg(
 ///
 /// # Arguments
 ///
-/// * `amount` - Uint128 amount of tokens to mint
 /// * `recipient` - reference to address that will receive the newly minted tokens
+/// * `amount` - Uint128 amount of tokens to mint
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad message to blocks of this size
 /// * `callback_code_hash` - string slice holding the code hash of contract being called
 /// * `contract_addr` - reference to address of contract being called
 pub fn mint_msg(
-    amount: Uint128,
     recipient: &HumanAddr,
+    amount: Uint128,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: &str,
     contract_addr: &HumanAddr,
 ) -> StdResult<CosmosMsg> {
     Snip20HandleMsg::Mint {
+        recipient,
         amount,
-        //TODO rename to recipient when reference impl does
-        address: recipient,
         padding,
     }
     .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)

--- a/packages/snip20/src/handle.rs
+++ b/packages/snip20/src/handle.rs
@@ -1,0 +1,565 @@
+use serde::Serialize;
+
+use cosmwasm_std::{to_binary, Binary, Coin, CosmosMsg, HumanAddr, StdResult, Uint128, WasmMsg};
+
+use secret_toolkit_utils::space_pad;
+
+/// enumerate all the handle messages of SNIP20 token
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Snip20HandleMsg<'a> {
+    /// Native coin interactions
+    Redeem {
+        amount: Uint128,
+        // TO DO: remove skip_serializing once denom is added to reference impl
+        #[serde(skip_serializing_if = "Option::is_none")]
+        denom: Option<String>,
+        padding: Option<String>,
+    },
+    Deposit {
+        padding: Option<String>,
+    },
+
+    /// Basic SNIP20 functions
+    Transfer {
+        recipient: &'a HumanAddr,
+        amount: Uint128,
+        padding: Option<String>,
+    },
+    Send {
+        recipient: &'a HumanAddr,
+        amount: Uint128,
+        msg: Option<Binary>,
+        padding: Option<String>,
+    },
+    Burn {
+        amount: Uint128,
+        padding: Option<String>,
+    },
+    SetViewingKey {
+        key: &'a str,
+        padding: Option<String>,
+    },
+
+    /// Allowance functions
+    IncreaseAllowance {
+        spender: &'a HumanAddr,
+        amount: Uint128,
+        expiration: Option<u64>,
+        padding: Option<String>,
+    },
+    DecreaseAllowance {
+        spender: &'a HumanAddr,
+        amount: Uint128,
+        expiration: Option<u64>,
+        padding: Option<String>,
+    },
+    TransferFrom {
+        owner: &'a HumanAddr,
+        recipient: &'a HumanAddr,
+        amount: Uint128,
+        padding: Option<String>,
+    },
+    SendFrom {
+        owner: &'a HumanAddr,
+        recipient: &'a HumanAddr,
+        amount: Uint128,
+        msg: Option<Binary>,
+        padding: Option<String>,
+    },
+    BurnFrom {
+        owner: &'a HumanAddr,
+        amount: Uint128,
+        padding: Option<String>,
+    },
+
+    /// Mint
+    Mint {
+        amount: Uint128,
+        // TO DO change name to recipient when reference impl does
+        address: &'a HumanAddr,
+        padding: Option<String>,
+    },
+    AddMinters {
+        minters: &'a [HumanAddr],
+        padding: Option<String>,
+    },
+    RemoveMinters {
+        minters: &'a [HumanAddr],
+        padding: Option<String>,
+    },
+    SetMinters {
+        minters: &'a [HumanAddr],
+        padding: Option<String>,
+    },
+
+    /// Set up Send/Receive functionality
+    RegisterReceive {
+        code_hash: &'a str,
+        padding: Option<String>,
+    },
+}
+
+impl<'a> Snip20HandleMsg<'a> {
+    /// Returns a StdResult<CosmosMsg> used to execute a SNIP20 contract function
+    ///
+    /// # Arguments
+    ///
+    /// * `block_size` - pad message to blocks of this size
+    /// * `callback_code_hash` - string slice holding the code hash of contract being called
+    /// * `contract_addr` - reference to address of contract being called
+    /// * `send_amount` - Optional Uint128 amount of native coin to send with the callback message
+    ///                 NOTE: Only a Deposit message should have an amount sent with it
+    pub fn to_cosmos_msg(
+        &'a self,
+        block_size: usize,
+        callback_code_hash: &'a str,
+        contract_addr: &'a HumanAddr,
+        send_amount: Option<Uint128>,
+    ) -> StdResult<CosmosMsg> {
+        let pad_block_size: usize;
+        // can not have block size of 0
+        if block_size == 0 {
+            pad_block_size = 1;
+        } else {
+            pad_block_size = block_size;
+        }
+        let mut msg = to_binary(self)?;
+        space_pad(&mut msg.0, pad_block_size);
+        let mut send = Vec::new();
+        if let Some(amount) = send_amount {
+            send.push(Coin {
+                amount,
+                denom: String::from("uscrt"),
+            });
+        }
+        let execute = WasmMsg::Execute {
+            msg,
+            contract_addr: contract_addr.clone(),
+            callback_code_hash: callback_code_hash.to_string(),
+            send,
+        };
+        Ok(execute.into())
+    }
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Redeem
+///
+/// # Arguments
+///
+/// * `amount` - Uint128 amount of token to redeem for SCRT
+/// * `denom` - Optional String to hold denomination of tokens to mint
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn redeem_msg(
+    amount: Uint128,
+    denom: Option<String>,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Redeem {
+        amount,
+        denom,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Deposit
+///
+/// # Arguments
+///
+/// * `amount` - Uint128 amount of uSCRT to convert to SNIP20 token
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn deposit_msg(
+    amount: Uint128,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Deposit { padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        Some(amount),
+    )
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Transfer
+///
+/// # Arguments
+///
+/// * `recipient` - reference to address tokens are to be sent to
+/// * `amount` - Uint128 amount of tokens to send
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn transfer_msg(
+    recipient: &HumanAddr,
+    amount: Uint128,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Transfer {
+        recipient,
+        amount,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Send
+///
+/// # Arguments
+///
+/// * `recipient` - reference to address tokens are to be sent to
+/// * `amount` - Uint128 amount of tokens to send
+/// * `msg` - Optional base64 encoded string to pass to contract for Receive function
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn send_msg(
+    recipient: &HumanAddr,
+    amount: Uint128,
+    msg: Option<Binary>,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Send {
+        recipient,
+        amount,
+        msg,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Burn
+///
+/// # Arguments
+///
+/// * `amount` - Uint128 amount of tokens to burn
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn burn_msg(
+    amount: Uint128,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Burn { amount, padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        None,
+    )
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute RegisterReceive
+///
+/// # Arguments
+///
+/// * `your_contracts_code_hash` - string slice holding code hash of your contract
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn register_receive_msg(
+    your_contracts_code_hash: &str,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::RegisterReceive {
+        code_hash: your_contracts_code_hash,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute SetViewingKey
+///
+/// # Arguments
+///
+/// * `key` - string slice holding the authentication key used for later queries
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn set_viewing_key_msg(
+    key: &str,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::SetViewingKey { key, padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        None,
+    )
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute IncreaseAllowance
+///
+/// # Arguments
+///
+/// * `spender` - reference to address of the allowed spender
+/// * `amount` - Uint128 additional amount spender is allowed to send/burn
+/// * `expiration` - Optional u64 denoting epoch time in seconds that allowance will expire
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn increase_allowance_msg(
+    spender: &HumanAddr,
+    amount: Uint128,
+    expiration: Option<u64>,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::IncreaseAllowance {
+        spender,
+        amount,
+        expiration,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute DecreaseAllowance
+///
+/// # Arguments
+///
+/// * `spender` - reference to address of the allowed spender
+/// * `amount` - Uint128 amount spender is no longer allowed to send/burn
+/// * `expiration` - Optional u64 denoting epoch time in seconds that allowance will expire
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn decrease_allowance_msg(
+    spender: &HumanAddr,
+    amount: Uint128,
+    expiration: Option<u64>,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::DecreaseAllowance {
+        spender,
+        amount,
+        expiration,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute TransferFrom
+///
+/// # Arguments
+///
+/// * `owner` - reference to address of the owner of the tokens to be sent
+/// * `recipient` - reference to address tokens are to be sent to
+/// * `amount` - Uint128 amount of tokens to send
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn transfer_from_msg(
+    owner: &HumanAddr,
+    recipient: &HumanAddr,
+    amount: Uint128,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::TransferFrom {
+        owner,
+        recipient,
+        amount,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute SendFrom
+///
+/// # Arguments
+///
+/// * `owner` - reference to address of the owner of the tokens to be sent
+/// * `recipient` - reference to address tokens are to be sent to
+/// * `amount` - Uint128 amount of tokens to send
+/// * `msg` - Optional base64 encoded string to pass to contract for Receive function
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+#[allow(clippy::too_many_arguments)]
+pub fn send_from_msg(
+    owner: &HumanAddr,
+    recipient: &HumanAddr,
+    amount: Uint128,
+    msg: Option<Binary>,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::SendFrom {
+        owner,
+        recipient,
+        amount,
+        msg,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute BurnFrom
+///
+/// # Arguments
+///
+/// * `owner` - reference to address of the owner of the tokens to be burnt
+/// * `amount` - Uint128 amount of tokens to burn
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn burn_from_msg(
+    owner: &HumanAddr,
+    amount: Uint128,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::BurnFrom {
+        owner,
+        amount,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute Mint
+///
+/// # Arguments
+///
+/// * `amount` - Uint128 amount of tokens to mint
+/// * `recipient` - reference to address that will receive the newly minted tokens
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn mint_msg(
+    amount: Uint128,
+    recipient: &HumanAddr,
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::Mint {
+        amount,
+        //TODO rename to recipient when reference impl does
+        address: recipient,
+        padding,
+    }
+    .to_cosmos_msg(block_size, callback_code_hash, contract_addr, None)
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute AddMinters
+///
+/// # Arguments
+///
+/// * `minters` - slice of list of new addresses that will be allowed to mint
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn add_minters_msg(
+    minters: &[HumanAddr],
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::AddMinters { minters, padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        None,
+    )
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute RemoveMinters
+///
+/// # Arguments
+///
+/// * `minters` - slice of list of addresses that are no longer allowed to mint
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn remove_minters_msg(
+    minters: &[HumanAddr],
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::RemoveMinters { minters, padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        None,
+    )
+}
+
+/// Returns a StdResult<CosmosMsg> used to execute SetMinters
+///
+/// # Arguments
+///
+/// * `minters` - slice of list of the only addresses that are allowed to mint
+/// * `padding` - Optional String used as padding if you don't want to use block padding
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being called
+/// * `contract_addr` - reference to address of contract being called
+pub fn set_minters_msg(
+    minters: &[HumanAddr],
+    padding: Option<String>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<CosmosMsg> {
+    Snip20HandleMsg::SetMinters { minters, padding }.to_cosmos_msg(
+        block_size,
+        callback_code_hash,
+        contract_addr,
+        None,
+    )
+}

--- a/packages/snip20/src/handle.rs
+++ b/packages/snip20/src/handle.rs
@@ -7,7 +7,7 @@ use secret_toolkit_utils::space_pad;
 /// SNIP20 token handle messages
 #[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub enum HandleMsg<'a> {
+pub enum HandleMsg {
     // Native coin interactions
     Redeem {
         amount: Uint128,
@@ -22,12 +22,12 @@ pub enum HandleMsg<'a> {
 
     // Basic SNIP20 functions
     Transfer {
-        recipient: &'a HumanAddr,
+        recipient: HumanAddr,
         amount: Uint128,
         padding: Option<String>,
     },
     Send {
-        recipient: &'a HumanAddr,
+        recipient: HumanAddr,
         amount: Uint128,
         msg: Option<Binary>,
         padding: Option<String>,
@@ -37,69 +37,69 @@ pub enum HandleMsg<'a> {
         padding: Option<String>,
     },
     SetViewingKey {
-        key: &'a str,
+        key: String,
         padding: Option<String>,
     },
 
     // Allowance functions
     IncreaseAllowance {
-        spender: &'a HumanAddr,
+        spender: HumanAddr,
         amount: Uint128,
         expiration: Option<u64>,
         padding: Option<String>,
     },
     DecreaseAllowance {
-        spender: &'a HumanAddr,
+        spender: HumanAddr,
         amount: Uint128,
         expiration: Option<u64>,
         padding: Option<String>,
     },
     TransferFrom {
-        owner: &'a HumanAddr,
-        recipient: &'a HumanAddr,
+        owner: HumanAddr,
+        recipient: HumanAddr,
         amount: Uint128,
         padding: Option<String>,
     },
     SendFrom {
-        owner: &'a HumanAddr,
-        recipient: &'a HumanAddr,
+        owner: HumanAddr,
+        recipient: HumanAddr,
         amount: Uint128,
         msg: Option<Binary>,
         padding: Option<String>,
     },
     BurnFrom {
-        owner: &'a HumanAddr,
+        owner: HumanAddr,
         amount: Uint128,
         padding: Option<String>,
     },
 
     // Mint
     Mint {
-        recipient: &'a HumanAddr,
+        recipient: HumanAddr,
         amount: Uint128,
         padding: Option<String>,
     },
     AddMinters {
-        minters: &'a [HumanAddr],
+        minters: Vec<HumanAddr>,
         padding: Option<String>,
     },
     RemoveMinters {
-        minters: &'a [HumanAddr],
+        minters: Vec<HumanAddr>,
         padding: Option<String>,
     },
     SetMinters {
-        minters: &'a [HumanAddr],
+        minters: Vec<HumanAddr>,
         padding: Option<String>,
     },
 
     // Set up Send/Receive functionality
     RegisterReceive {
-        code_hash: &'a str,
+        code_hash: String,
         padding: Option<String>,
     },
 }
 
-impl<'a> HandleMsg<'a> {
+impl HandleMsg {
     /// Returns a StdResult<CosmosMsg> used to execute a SNIP20 contract function
     ///
     /// # Arguments
@@ -193,14 +193,14 @@ pub fn deposit_msg(
 ///
 /// # Arguments
 ///
-/// * `recipient` - a reference to the address the tokens are to be sent to
+/// * `recipient` - the address the tokens are to be sent to
 /// * `amount` - Uint128 amount of tokens to send
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn transfer_msg(
-    recipient: &HumanAddr,
+    recipient: HumanAddr,
     amount: Uint128,
     padding: Option<String>,
     block_size: usize,
@@ -219,7 +219,7 @@ pub fn transfer_msg(
 ///
 /// # Arguments
 ///
-/// * `recipient` - a reference to the address tokens are to be sent to
+/// * `recipient` - the address tokens are to be sent to
 /// * `amount` - Uint128 amount of tokens to send
 /// * `msg` - Optional base64 encoded string to pass to the recipient contract's
 ///           Receive function
@@ -228,7 +228,7 @@ pub fn transfer_msg(
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn send_msg(
-    recipient: &HumanAddr,
+    recipient: HumanAddr,
     amount: Uint128,
     msg: Option<Binary>,
     padding: Option<String>,
@@ -273,13 +273,13 @@ pub fn burn_msg(
 ///
 /// # Arguments
 ///
-/// * `your_contracts_code_hash` - string slice holding the code hash of your contract
+/// * `your_contracts_code_hash` - String holding the code hash of your contract
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn register_receive_msg(
-    your_contracts_code_hash: &str,
+    your_contracts_code_hash: String,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: String,
@@ -296,13 +296,13 @@ pub fn register_receive_msg(
 ///
 /// # Arguments
 ///
-/// * `key` - string slice holding the authentication key used for later queries
+/// * `key` - String holding the authentication key used for later queries
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn set_viewing_key_msg(
-    key: &str,
+    key: String,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: String,
@@ -320,7 +320,7 @@ pub fn set_viewing_key_msg(
 ///
 /// # Arguments
 ///
-/// * `spender` - a reference to the address of the allowed spender
+/// * `spender` - the address of the allowed spender
 /// * `amount` - Uint128 additional amount the spender is allowed to send/burn
 /// * `expiration` - Optional u64 denoting the epoch time in seconds that the allowance will expire
 /// * `padding` - Optional String used as padding if you don't want to use block padding
@@ -328,7 +328,7 @@ pub fn set_viewing_key_msg(
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn increase_allowance_msg(
-    spender: &HumanAddr,
+    spender: HumanAddr,
     amount: Uint128,
     expiration: Option<u64>,
     padding: Option<String>,
@@ -349,7 +349,7 @@ pub fn increase_allowance_msg(
 ///
 /// # Arguments
 ///
-/// * `spender` - a reference to the address of the allowed spender
+/// * `spender` - the address of the allowed spender
 /// * `amount` - Uint128 amount the spender is no longer allowed to send/burn
 /// * `expiration` - Optional u64 denoting the epoch time in seconds that the allowance will expire
 /// * `padding` - Optional String used as padding if you don't want to use block padding
@@ -357,7 +357,7 @@ pub fn increase_allowance_msg(
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn decrease_allowance_msg(
-    spender: &HumanAddr,
+    spender: HumanAddr,
     amount: Uint128,
     expiration: Option<u64>,
     padding: Option<String>,
@@ -378,16 +378,16 @@ pub fn decrease_allowance_msg(
 ///
 /// # Arguments
 ///
-/// * `owner` - a reference to the address of the owner of the tokens to be sent
-/// * `recipient` - a reference to the address the tokens are to be sent to
+/// * `owner` - the address of the owner of the tokens to be sent
+/// * `recipient` - the address the tokens are to be sent to
 /// * `amount` - Uint128 amount of tokens to send
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn transfer_from_msg(
-    owner: &HumanAddr,
-    recipient: &HumanAddr,
+    owner: HumanAddr,
+    recipient: HumanAddr,
     amount: Uint128,
     padding: Option<String>,
     block_size: usize,
@@ -407,8 +407,8 @@ pub fn transfer_from_msg(
 ///
 /// # Arguments
 ///
-/// * `owner` - a reference to the address of the owner of the tokens to be sent
-/// * `recipient` - a reference to the address the tokens are to be sent to
+/// * `owner` - the address of the owner of the tokens to be sent
+/// * `recipient` - the address the tokens are to be sent to
 /// * `amount` - Uint128 amount of tokens to send
 /// * `msg` - Optional base64 encoded string to pass to the recipient contract's
 ///           Receive function
@@ -418,8 +418,8 @@ pub fn transfer_from_msg(
 /// * `contract_addr` - address of the contract being called
 #[allow(clippy::too_many_arguments)]
 pub fn send_from_msg(
-    owner: &HumanAddr,
-    recipient: &HumanAddr,
+    owner: HumanAddr,
+    recipient: HumanAddr,
     amount: Uint128,
     msg: Option<Binary>,
     padding: Option<String>,
@@ -441,14 +441,14 @@ pub fn send_from_msg(
 ///
 /// # Arguments
 ///
-/// * `owner` - a reference to the address of the owner of the tokens to be burnt
+/// * `owner` - the address of the owner of the tokens to be burnt
 /// * `amount` - Uint128 amount of tokens to burn
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn burn_from_msg(
-    owner: &HumanAddr,
+    owner: HumanAddr,
     amount: Uint128,
     padding: Option<String>,
     block_size: usize,
@@ -467,14 +467,14 @@ pub fn burn_from_msg(
 ///
 /// # Arguments
 ///
-/// * `recipient` - a reference to the address that will receive the newly minted tokens
+/// * `recipient` - the address that will receive the newly minted tokens
 /// * `amount` - Uint128 amount of tokens to mint
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn mint_msg(
-    recipient: &HumanAddr,
+    recipient: HumanAddr,
     amount: Uint128,
     padding: Option<String>,
     block_size: usize,
@@ -493,13 +493,13 @@ pub fn mint_msg(
 ///
 /// # Arguments
 ///
-/// * `minters` - slice of a list of new addresses that will be allowed to mint
+/// * `minters` - list of new addresses that will be allowed to mint
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn add_minters_msg(
-    minters: &[HumanAddr],
+    minters: Vec<HumanAddr>,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: String,
@@ -517,13 +517,13 @@ pub fn add_minters_msg(
 ///
 /// # Arguments
 ///
-/// * `minters` - slice of a list of addresses that are no longer allowed to mint
+/// * `minters` - list of addresses that are no longer allowed to mint
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn remove_minters_msg(
-    minters: &[HumanAddr],
+    minters: Vec<HumanAddr>,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: String,
@@ -541,13 +541,13 @@ pub fn remove_minters_msg(
 ///
 /// # Arguments
 ///
-/// * `minters` - slice of a list of the only addresses that are allowed to mint
+/// * `minters` - list of the only addresses that are allowed to mint
 /// * `padding` - Optional String used as padding if you don't want to use block padding
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being called
 /// * `contract_addr` - address of the contract being called
 pub fn set_minters_msg(
-    minters: &[HumanAddr],
+    minters: Vec<HumanAddr>,
     padding: Option<String>,
     block_size: usize,
     callback_code_hash: String,

--- a/packages/snip20/src/handle.rs
+++ b/packages/snip20/src/handle.rs
@@ -4,11 +4,11 @@ use cosmwasm_std::{to_binary, Binary, Coin, CosmosMsg, HumanAddr, StdResult, Uin
 
 use secret_toolkit_utils::space_pad;
 
-/// enumerate all the handle messages of SNIP20 token
+/// SNIP20 token handle messages
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Snip20HandleMsg<'a> {
-    /// Native coin interactions
+    // Native coin interactions
     Redeem {
         amount: Uint128,
         // TO DO: remove skip_serializing once denom is added to sSCRT stored on mainnet
@@ -20,7 +20,7 @@ pub enum Snip20HandleMsg<'a> {
         padding: Option<String>,
     },
 
-    /// Basic SNIP20 functions
+    // Basic SNIP20 functions
     Transfer {
         recipient: &'a HumanAddr,
         amount: Uint128,
@@ -41,7 +41,7 @@ pub enum Snip20HandleMsg<'a> {
         padding: Option<String>,
     },
 
-    /// Allowance functions
+    // Allowance functions
     IncreaseAllowance {
         spender: &'a HumanAddr,
         amount: Uint128,
@@ -73,7 +73,7 @@ pub enum Snip20HandleMsg<'a> {
         padding: Option<String>,
     },
 
-    /// Mint
+    // Mint
     Mint {
         recipient: &'a HumanAddr,
         amount: Uint128,
@@ -92,7 +92,7 @@ pub enum Snip20HandleMsg<'a> {
         padding: Option<String>,
     },
 
-    /// Set up Send/Receive functionality
+    // Set up Send/Receive functionality
     RegisterReceive {
         code_hash: &'a str,
         padding: Option<String>,

--- a/packages/snip20/src/handle.rs
+++ b/packages/snip20/src/handle.rs
@@ -5,13 +5,13 @@ use cosmwasm_std::{to_binary, Binary, Coin, CosmosMsg, HumanAddr, StdResult, Uin
 use secret_toolkit_utils::space_pad;
 
 /// SNIP20 token handle messages
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HandleMsg<'a> {
     // Native coin interactions
     Redeem {
         amount: Uint128,
-        // TO DO: remove skip_serializing once denom is added to sSCRT stored on mainnet
+        // TODO: remove skip_serializing once denom is added to sSCRT stored on mainnet
         #[serde(skip_serializing_if = "Option::is_none")]
         denom: Option<String>,
         padding: Option<String>,

--- a/packages/snip20/src/lib.rs
+++ b/packages/snip20/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod handle;
+pub mod query;
+
+pub use handle::*;
+pub use query::*;

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use cosmwasm_std::{
@@ -8,8 +9,8 @@ use cosmwasm_std::{
 
 use secret_toolkit_utils::space_pad;
 
-/// query response structs
-#[derive(Serialize, Deserialize)]
+/// TokenInfo response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TokenInfo {
     pub name: String,
     pub symbol: String,
@@ -17,12 +18,14 @@ pub struct TokenInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_supply: Option<Uint128>,
 }
-#[derive(Serialize, Deserialize)]
+/// ExchangeRate response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ExchangeRate {
     pub rate: Uint128,
     pub denom: String,
 }
-#[derive(Serialize, Deserialize)]
+/// Allowance response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Allowance {
     pub spender: HumanAddr,
     pub owner: HumanAddr,
@@ -30,11 +33,13 @@ pub struct Allowance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<u64>,
 }
-#[derive(Serialize, Deserialize)]
+/// Balance response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Balance {
     pub amount: Uint128,
 }
-#[derive(Serialize, Deserialize)]
+/// Transaction data
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Tx {
     pub id: u64,
     pub from: HumanAddr,
@@ -42,16 +47,18 @@ pub struct Tx {
     pub receiver: HumanAddr,
     pub coins: Coin,
 }
-#[derive(Serialize, Deserialize)]
+/// TransferHistory response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TransferHistory {
     pub txs: Vec<Tx>,
 }
-#[derive(Serialize, Deserialize)]
+/// Minters response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Minters {
     pub minters: Vec<HumanAddr>,
 }
 
-/// enumerate all the SNIP20 queries
+/// SNIP20 queries
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Snip20QueryMsg<'a> {
@@ -125,27 +132,32 @@ impl<'a> Snip20QueryMsg<'a> {
     }
 }
 
-/// wrappers so that query responses deserialize correctly
+/// wrapper to deserialize TokenInfo response
 #[derive(Deserialize)]
 pub struct TokenInfoResponse {
     pub token_info: TokenInfo,
 }
+/// wrapper to deserialize ExchangeRate response
 #[derive(Deserialize)]
 pub struct ExchangeRateResponse {
     pub exchange_rate: ExchangeRate,
 }
+/// wrapper to deserialize Allowance response
 #[derive(Deserialize)]
 pub struct AllowanceResponse {
     pub allowance: Allowance,
 }
+/// wrapper to deserialize Balance response
 #[derive(Deserialize)]
 pub struct BalanceResponse {
     pub balance: Balance,
 }
+/// wrapper to deserialize TransferHistory response
 #[derive(Deserialize)]
 pub struct TransferHistoryResponse {
     pub transfer_history: TransferHistory,
 }
+/// wrapper to deserialize Minters response
 #[derive(Deserialize)]
 pub struct MintersResponse {
     pub minters: Minters,

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -18,12 +18,14 @@ pub struct TokenInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_supply: Option<Uint128>,
 }
+
 /// ExchangeRate response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ExchangeRate {
     pub rate: Uint128,
     pub denom: String,
 }
+
 /// Allowance response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Allowance {
@@ -33,11 +35,13 @@ pub struct Allowance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<u64>,
 }
+
 /// Balance response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Balance {
     pub amount: Uint128,
 }
+
 /// Transaction data
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Tx {
@@ -47,11 +51,13 @@ pub struct Tx {
     pub receiver: HumanAddr,
     pub coins: Coin,
 }
+
 /// TransferHistory response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TransferHistory {
     pub txs: Vec<Tx>,
 }
+
 /// Minters response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Minters {
@@ -61,7 +67,7 @@ pub struct Minters {
 /// SNIP20 queries
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Snip20QueryMsg<'a> {
+pub enum QueryMsg<'a> {
     TokenInfo {},
     ExchangeRate {},
     Allowance {
@@ -82,48 +88,45 @@ pub enum Snip20QueryMsg<'a> {
     Minters {},
 }
 
-impl<'a> fmt::Display for Snip20QueryMsg<'a> {
+impl<'a> fmt::Display for QueryMsg<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Snip20QueryMsg::TokenInfo { .. } => write!(f, "TokenInfo"),
-            Snip20QueryMsg::ExchangeRate { .. } => write!(f, "ExchangeRate"),
-            Snip20QueryMsg::Allowance { .. } => write!(f, "Allowance"),
-            Snip20QueryMsg::Balance { .. } => write!(f, "Balance"),
-            Snip20QueryMsg::TransferHistory { .. } => write!(f, "TransferHistory"),
-            Snip20QueryMsg::Minters { .. } => write!(f, "Minters"),
+            QueryMsg::TokenInfo { .. } => write!(f, "TokenInfo"),
+            QueryMsg::ExchangeRate { .. } => write!(f, "ExchangeRate"),
+            QueryMsg::Allowance { .. } => write!(f, "Allowance"),
+            QueryMsg::Balance { .. } => write!(f, "Balance"),
+            QueryMsg::TransferHistory { .. } => write!(f, "TransferHistory"),
+            QueryMsg::Minters { .. } => write!(f, "Minters"),
         }
     }
 }
 
-impl<'a> Snip20QueryMsg<'a> {
+impl<'a> QueryMsg<'a> {
     /// Returns a StdResult<T>, where T is the "Response" type that wraps the query answer
     ///
     /// # Arguments
     ///
-    /// * `deps` - reference to Extern that holds all the external contract dependencies
-    /// * `block_size` - pad message to blocks of this size
-    /// * `callback_code_hash` - string slice holding the code hash of contract being queried
-    /// * `contract_addr` - reference to address of contract being queries
+    /// * `deps` - a reference to the Extern that holds all the external contract dependencies
+    /// * `block_size` - pad the message to blocks of this size
+    /// * `callback_code_hash` - String holding the code hash of the contract being queried
+    /// * `contract_addr` - address of the contract being queried
     pub fn query<S: Storage, A: Api, Q: Querier, T: DeserializeOwned>(
-        &'a self,
-        deps: &'a Extern<S, A, Q>,
-        block_size: usize,
-        callback_code_hash: &'a str,
-        contract_addr: &'a HumanAddr,
+        &self,
+        deps: &Extern<S, A, Q>,
+        mut block_size: usize,
+        callback_code_hash: String,
+        contract_addr: HumanAddr,
     ) -> StdResult<T> {
-        let pad_block_size: usize;
         // can not have block size of 0
         if block_size == 0 {
-            pad_block_size = 1;
-        } else {
-            pad_block_size = block_size;
+            block_size = 1;
         }
         let mut msg = to_binary(self)?;
-        space_pad(&mut msg.0, pad_block_size);
+        space_pad(&mut msg.0, block_size);
         deps.querier
             .query(&QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: contract_addr.clone(),
-                callback_code_hash: callback_code_hash.to_string(),
+                contract_addr,
+                callback_code_hash,
                 msg,
             }))
             .map_err(|err| {
@@ -137,26 +140,31 @@ impl<'a> Snip20QueryMsg<'a> {
 pub struct TokenInfoResponse {
     pub token_info: TokenInfo,
 }
+
 /// wrapper to deserialize ExchangeRate response
 #[derive(Deserialize)]
 pub struct ExchangeRateResponse {
     pub exchange_rate: ExchangeRate,
 }
+
 /// wrapper to deserialize Allowance response
 #[derive(Deserialize)]
 pub struct AllowanceResponse {
     pub allowance: Allowance,
 }
+
 /// wrapper to deserialize Balance response
 #[derive(Deserialize)]
 pub struct BalanceResponse {
     pub balance: Balance,
 }
+
 /// wrapper to deserialize TransferHistory response
 #[derive(Deserialize)]
 pub struct TransferHistoryResponse {
     pub transfer_history: TransferHistory,
 }
+
 /// wrapper to deserialize Minters response
 #[derive(Deserialize)]
 pub struct MintersResponse {
@@ -167,18 +175,18 @@ pub struct MintersResponse {
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 pub fn token_info_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<TokenInfo> {
     let answer: TokenInfoResponse =
-        Snip20QueryMsg::TokenInfo {}.query(deps, block_size, callback_code_hash, contract_addr)?;
+        QueryMsg::TokenInfo {}.query(deps, block_size, callback_code_hash, contract_addr)?;
     Ok(answer.token_info)
 }
 
@@ -186,22 +194,18 @@ pub fn token_info_query<S: Storage, A: Api, Q: Querier>(
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 pub fn exchange_rate_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<ExchangeRate> {
-    let answer: ExchangeRateResponse = Snip20QueryMsg::ExchangeRate {}.query(
-        deps,
-        block_size,
-        callback_code_hash,
-        contract_addr,
-    )?;
+    let answer: ExchangeRateResponse =
+        QueryMsg::ExchangeRate {}.query(deps, block_size, callback_code_hash, contract_addr)?;
     Ok(answer.exchange_rate)
 }
 
@@ -209,13 +213,13 @@ pub fn exchange_rate_query<S: Storage, A: Api, Q: Querier>(
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `owner` - reference to address that owns the tokens
-/// * `spender` - reference to address allowed to send/burn tokens
-/// * `key` - string slice holding the authentication key needed to view allowance
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `owner` - a reference to the address that owns the tokens
+/// * `spender` - a reference to the address allowed to send/burn tokens
+/// * `key` - string slice holding the authentication key needed to view the allowance
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 #[allow(clippy::too_many_arguments)]
 pub fn allowance_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
@@ -223,10 +227,10 @@ pub fn allowance_query<S: Storage, A: Api, Q: Querier>(
     spender: &HumanAddr,
     key: &str,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<Allowance> {
-    let answer: AllowanceResponse = Snip20QueryMsg::Allowance {
+    let answer: AllowanceResponse = QueryMsg::Allowance {
         owner,
         spender,
         key,
@@ -239,21 +243,21 @@ pub fn allowance_query<S: Storage, A: Api, Q: Querier>(
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `address` - reference to address whose balance should be displayed
-/// * `key` - string slice holding the authentication key needed to view balance
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `address` - a reference to the address whose balance should be displayed
+/// * `key` - string slice holding the authentication key needed to view the balance
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 pub fn balance_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     address: &HumanAddr,
     key: &str,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<Balance> {
-    let answer: BalanceResponse = Snip20QueryMsg::Balance { address, key }.query(
+    let answer: BalanceResponse = QueryMsg::Balance { address, key }.query(
         deps,
         block_size,
         callback_code_hash,
@@ -266,14 +270,14 @@ pub fn balance_query<S: Storage, A: Api, Q: Querier>(
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `address` - reference to address whose transaction history should be displayed
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `address` - a reference to the address whose transaction history should be displayed
 /// * `key` - string slice holding the authentication key needed to view transactions
-/// * `page` - Optional u32 representing page number of transactions to display
+/// * `page` - Optional u32 representing the page number of transactions to display
 /// * `page_size` - u32 number of transactions to return
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 #[allow(clippy::too_many_arguments)]
 pub fn transfer_history_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
@@ -282,10 +286,10 @@ pub fn transfer_history_query<S: Storage, A: Api, Q: Querier>(
     page: Option<u32>,
     page_size: u32,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<TransferHistory> {
-    let answer: TransferHistoryResponse = Snip20QueryMsg::TransferHistory {
+    let answer: TransferHistoryResponse = QueryMsg::TransferHistory {
         address,
         key,
         page,
@@ -299,17 +303,17 @@ pub fn transfer_history_query<S: Storage, A: Api, Q: Querier>(
 ///
 /// # Arguments
 ///
-/// * `deps` - reference to Extern that holds all the external contract dependencies
-/// * `block_size` - pad message to blocks of this size
-/// * `callback_code_hash` - string slice holding the code hash of contract being queried
-/// * `contract_addr` - reference to address of contract being queries
+/// * `deps` - a reference to the Extern that holds all the external contract dependencies
+/// * `block_size` - pad the message to blocks of this size
+/// * `callback_code_hash` - String holding the code hash of the contract being queried
+/// * `contract_addr` - address of the contract being queried
 pub fn minters_query<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     block_size: usize,
-    callback_code_hash: &str,
-    contract_addr: &HumanAddr,
+    callback_code_hash: String,
+    contract_addr: HumanAddr,
 ) -> StdResult<Minters> {
     let answer: MintersResponse =
-        Snip20QueryMsg::Minters {}.query(deps, block_size, callback_code_hash, contract_addr)?;
+        QueryMsg::Minters {}.query(deps, block_size, callback_code_hash, contract_addr)?;
     Ok(answer.minters)
 }

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -66,28 +66,28 @@ pub struct Minters {
 /// SNIP20 queries
 #[derive(Serialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryMsg<'a> {
+pub enum QueryMsg {
     TokenInfo {},
     ExchangeRate {},
     Allowance {
-        owner: &'a HumanAddr,
-        spender: &'a HumanAddr,
-        key: &'a str,
+        owner: HumanAddr,
+        spender: HumanAddr,
+        key: String,
     },
     Balance {
-        address: &'a HumanAddr,
-        key: &'a str,
+        address: HumanAddr,
+        key: String,
     },
     TransferHistory {
-        address: &'a HumanAddr,
-        key: &'a str,
+        address: HumanAddr,
+        key: String,
         page: Option<u32>,
         page_size: u32,
     },
     Minters {},
 }
 
-impl<'a> fmt::Display for QueryMsg<'a> {
+impl fmt::Display for QueryMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             QueryMsg::TokenInfo { .. } => write!(f, "TokenInfo"),
@@ -100,7 +100,7 @@ impl<'a> fmt::Display for QueryMsg<'a> {
     }
 }
 
-impl<'a> QueryMsg<'a> {
+impl QueryMsg {
     /// Returns a StdResult<T>, where T is the "Response" type that wraps the query answer
     ///
     /// # Arguments
@@ -213,18 +213,18 @@ pub fn exchange_rate_query<Q: Querier>(
 /// # Arguments
 ///
 /// * `querier` - a reference to the Querier dependency of the querying contract
-/// * `owner` - a reference to the address that owns the tokens
-/// * `spender` - a reference to the address allowed to send/burn tokens
-/// * `key` - string slice holding the authentication key needed to view the allowance
+/// * `owner` - the address that owns the tokens
+/// * `spender` - the address allowed to send/burn tokens
+/// * `key` - String holding the authentication key needed to view the allowance
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being queried
 /// * `contract_addr` - address of the contract being queried
 #[allow(clippy::too_many_arguments)]
 pub fn allowance_query<Q: Querier>(
     querier: &Q,
-    owner: &HumanAddr,
-    spender: &HumanAddr,
-    key: &str,
+    owner: HumanAddr,
+    spender: HumanAddr,
+    key: String,
     block_size: usize,
     callback_code_hash: String,
     contract_addr: HumanAddr,
@@ -243,15 +243,15 @@ pub fn allowance_query<Q: Querier>(
 /// # Arguments
 ///
 /// * `querier` - a reference to the Querier dependency of the querying contract
-/// * `address` - a reference to the address whose balance should be displayed
-/// * `key` - string slice holding the authentication key needed to view the balance
+/// * `address` - the address whose balance should be displayed
+/// * `key` - String holding the authentication key needed to view the balance
 /// * `block_size` - pad the message to blocks of this size
 /// * `callback_code_hash` - String holding the code hash of the contract being queried
 /// * `contract_addr` - address of the contract being queried
 pub fn balance_query<Q: Querier>(
     querier: &Q,
-    address: &HumanAddr,
-    key: &str,
+    address: HumanAddr,
+    key: String,
     block_size: usize,
     callback_code_hash: String,
     contract_addr: HumanAddr,
@@ -270,8 +270,8 @@ pub fn balance_query<Q: Querier>(
 /// # Arguments
 ///
 /// * `querier` - a reference to the Querier dependency of the querying contract
-/// * `address` - a reference to the address whose transaction history should be displayed
-/// * `key` - string slice holding the authentication key needed to view transactions
+/// * `address` - the address whose transaction history should be displayed
+/// * `key` - String holding the authentication key needed to view transactions
 /// * `page` - Optional u32 representing the page number of transactions to display
 /// * `page_size` - u32 number of transactions to return
 /// * `block_size` - pad the message to blocks of this size
@@ -280,8 +280,8 @@ pub fn balance_query<Q: Querier>(
 #[allow(clippy::too_many_arguments)]
 pub fn transfer_history_query<Q: Querier>(
     querier: &Q,
-    address: &HumanAddr,
-    key: &str,
+    address: HumanAddr,
+    key: String,
     page: Option<u32>,
     page_size: u32,
     block_size: usize,

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -1,0 +1,303 @@
+use core::fmt;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use cosmwasm_std::{
+    to_binary, Api, Coin, Extern, HumanAddr, Querier, QueryRequest, StdError, StdResult, Storage,
+    Uint128, WasmQuery,
+};
+
+use secret_toolkit_utils::space_pad;
+
+/// query response structs
+#[derive(Serialize, Deserialize)]
+pub struct TokenInfo {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_supply: Option<Uint128>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct ExchangeRate {
+    pub rate: Uint128,
+    pub denom: String,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Allowance {
+    pub spender: HumanAddr,
+    pub owner: HumanAddr,
+    pub allowance: Uint128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration: Option<u64>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Balance {
+    pub amount: Uint128,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Tx {
+    pub id: u64,
+    pub from: HumanAddr,
+    pub sender: HumanAddr,
+    pub receiver: HumanAddr,
+    pub coins: Coin,
+}
+#[derive(Serialize, Deserialize)]
+pub struct TransferHistory {
+    pub txs: Vec<Tx>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Minters {
+    pub minters: Vec<HumanAddr>,
+}
+
+/// enumerate all the SNIP20 queries
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Snip20QueryMsg<'a> {
+    TokenInfo {},
+    ExchangeRate {},
+    Allowance {
+        owner: &'a HumanAddr,
+        spender: &'a HumanAddr,
+        key: &'a str,
+    },
+    Balance {
+        address: &'a HumanAddr,
+        key: &'a str,
+    },
+    TransferHistory {
+        address: &'a HumanAddr,
+        key: &'a str,
+        page: Option<u32>,
+        page_size: u32,
+    },
+    Minters {},
+}
+
+impl<'a> fmt::Display for Snip20QueryMsg<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Snip20QueryMsg::TokenInfo { .. } => write!(f, "TokenInfo"),
+            Snip20QueryMsg::ExchangeRate { .. } => write!(f, "ExchangeRate"),
+            Snip20QueryMsg::Allowance { .. } => write!(f, "Allowance"),
+            Snip20QueryMsg::Balance { .. } => write!(f, "Balance"),
+            Snip20QueryMsg::TransferHistory { .. } => write!(f, "TransferHistory"),
+            Snip20QueryMsg::Minters { .. } => write!(f, "Minters"),
+        }
+    }
+}
+
+impl<'a> Snip20QueryMsg<'a> {
+    /// Returns a StdResult<T>, where T is the "Response" type that wraps the query answer
+    ///
+    /// # Arguments
+    ///
+    /// * `deps` - reference to Extern that holds all the external contract dependencies
+    /// * `block_size` - pad message to blocks of this size
+    /// * `callback_code_hash` - string slice holding the code hash of contract being queried
+    /// * `contract_addr` - reference to address of contract being queries
+    pub fn query<S: Storage, A: Api, Q: Querier, T: DeserializeOwned>(
+        &'a self,
+        deps: &'a Extern<S, A, Q>,
+        block_size: usize,
+        callback_code_hash: &'a str,
+        contract_addr: &'a HumanAddr,
+    ) -> StdResult<T> {
+        let pad_block_size: usize;
+        // can not have block size of 0
+        if block_size == 0 {
+            pad_block_size = 1;
+        } else {
+            pad_block_size = block_size;
+        }
+        let mut msg = to_binary(self)?;
+        space_pad(&mut msg.0, pad_block_size);
+        deps.querier
+            .query(&QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: contract_addr.clone(),
+                callback_code_hash: callback_code_hash.to_string(),
+                msg,
+            }))
+            .map_err(|err| {
+                StdError::generic_err(format!("Error performing {} query: {}", self, err))
+            })
+    }
+}
+
+/// wrappers so that query responses deserialize correctly
+#[derive(Deserialize)]
+pub struct TokenInfoResponse {
+    pub token_info: TokenInfo,
+}
+#[derive(Deserialize)]
+pub struct ExchangeRateResponse {
+    pub exchange_rate: ExchangeRate,
+}
+#[derive(Deserialize)]
+pub struct AllowanceResponse {
+    pub allowance: Allowance,
+}
+#[derive(Deserialize)]
+pub struct BalanceResponse {
+    pub balance: Balance,
+}
+#[derive(Deserialize)]
+pub struct TransferHistoryResponse {
+    pub transfer_history: TransferHistory,
+}
+#[derive(Deserialize)]
+pub struct MintersResponse {
+    pub minters: Minters,
+}
+
+/// Returns a StdResult<TokenInfo> from performing TokenInfo query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+pub fn token_info_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<TokenInfo> {
+    let answer: TokenInfoResponse =
+        Snip20QueryMsg::TokenInfo {}.query(deps, block_size, callback_code_hash, contract_addr)?;
+    Ok(answer.token_info)
+}
+
+/// Returns a StdResult<ExchangeRate> from performing ExchangeRate query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+pub fn exchange_rate_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<ExchangeRate> {
+    let answer: ExchangeRateResponse = Snip20QueryMsg::ExchangeRate {}.query(
+        deps,
+        block_size,
+        callback_code_hash,
+        contract_addr,
+    )?;
+    Ok(answer.exchange_rate)
+}
+
+/// Returns a StdResult<Allowance> from performing Allowance query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `owner` - reference to address that owns the tokens
+/// * `spender` - reference to address allowed to send/burn tokens
+/// * `key` - string slice holding the authentication key needed to view allowance
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+#[allow(clippy::too_many_arguments)]
+pub fn allowance_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    owner: &HumanAddr,
+    spender: &HumanAddr,
+    key: &str,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<Allowance> {
+    let answer: AllowanceResponse = Snip20QueryMsg::Allowance {
+        owner,
+        spender,
+        key,
+    }
+    .query(deps, block_size, callback_code_hash, contract_addr)?;
+    Ok(answer.allowance)
+}
+
+/// Returns a StdResult<Balance> from performing Balance query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `address` - reference to address whose balance should be displayed
+/// * `key` - string slice holding the authentication key needed to view balance
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+pub fn balance_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    address: &HumanAddr,
+    key: &str,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<Balance> {
+    let answer: BalanceResponse = Snip20QueryMsg::Balance { address, key }.query(
+        deps,
+        block_size,
+        callback_code_hash,
+        contract_addr,
+    )?;
+    Ok(answer.balance)
+}
+
+/// Returns a StdResult<TransferHistory> from performing TransferHistory query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `address` - reference to address whose transaction history should be displayed
+/// * `key` - string slice holding the authentication key needed to view transactions
+/// * `page` - Optional u32 representing page number of transactions to display
+/// * `page_size` - u32 number of transactions to return
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+#[allow(clippy::too_many_arguments)]
+pub fn transfer_history_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    address: &HumanAddr,
+    key: &str,
+    page: Option<u32>,
+    page_size: u32,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<TransferHistory> {
+    let answer: TransferHistoryResponse = Snip20QueryMsg::TransferHistory {
+        address,
+        key,
+        page,
+        page_size,
+    }
+    .query(deps, block_size, callback_code_hash, contract_addr)?;
+    Ok(answer.transfer_history)
+}
+
+/// Returns a StdResult<Minters> from performing Minters query
+///
+/// # Arguments
+///
+/// * `deps` - reference to Extern that holds all the external contract dependencies
+/// * `block_size` - pad message to blocks of this size
+/// * `callback_code_hash` - string slice holding the code hash of contract being queried
+/// * `contract_addr` - reference to address of contract being queries
+pub fn minters_query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    block_size: usize,
+    callback_code_hash: &str,
+    contract_addr: &HumanAddr,
+) -> StdResult<Minters> {
+    let answer: MintersResponse =
+        Snip20QueryMsg::Minters {}.query(deps, block_size, callback_code_hash, contract_addr)?;
+    Ok(answer.minters)
+}

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -8,3 +8,4 @@ secret-toolkit-crypto = { path = "../crypto" }
 secret-toolkit-serialization = { path = "../serialization" }
 secret-toolkit-storage = { path = "../storage" }
 secret-toolkit-utils = { path = "../utils" }
+secret-toolkit-snip20 = { path = "../snip20" }

--- a/packages/toolkit/src/lib.rs
+++ b/packages/toolkit/src/lib.rs
@@ -1,4 +1,5 @@
 pub use secret_toolkit_crypto as crypto;
 pub use secret_toolkit_serialization as serialization;
+pub use secret_toolkit_snip20 as snip20;
 pub use secret_toolkit_storage as storage;
 pub use secret_toolkit_utils as utils;


### PR DESCRIPTION
Since I wasn't sure whether we will be going with AddMinters and RemoveMinters or staying with SetMinters, I just left all three implemented.  I'll remove whichever is necessary once the final word is in. @reuvenpo Just let me know once you and Itzik decide.
Also there are a couple TODOs listed that correspond with some small changes that will be going into the SNIP20 spec/reference implementation.  They are coded to be compatible with the current snip20-reference-impl, and will be changed as soon as I update the reference impl

addresses enigmampc/SecretNetwork#608

--EDIT--
Removed most of those TODOs now that I have the reference-impl/secretSCRT updates done.  I'm leaving the one TODO until the update to handle a denom field in Redeem is live for secretSCRT on mainnet (it currently won't except `denom: null`, so removing the `...skip_serializing...` will break being able to use it with mainnet secretSCRT if removed to early)