### PR TITLE
[FIX] Make SHA256_HASH_SIZE public

### DIFF
--- a/packages/crypto/src/lib.rs
+++ b/packages/crypto/src/lib.rs
@@ -2,5 +2,5 @@ mod hash;
 mod rng;
 pub mod secp256k1;
 
-pub use hash::sha_256;
+pub use hash::{sha_256, SHA256_HASH_SIZE};
 pub use rng::Prng;


### PR DESCRIPTION
I just forgot to make the constant public, so when I wanted to use it, I just couldn't. 